### PR TITLE
feature: replace GetSchemaAsync with synchronous GetSchema method

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 |                  | In-memory tables                             | ❌      |                                                   |
 |                  | Object Store                                 | ❌      |                                                   |
 | **DataFrame**    | Count rows                                   | ✅      | `CountAsync()`                                    |
-|                  | Get schema                                   | ✅      | `GetSchemaAsync()` → Arrow Schema                 |
+|                  | Get schema                                   | ✅      | `GetSchema()` → Arrow Schema                 |
 |                  | Collect all data                             | ✅      | `CollectAsync()` → RecordBatches                  |
 |                  | Stream results                               | ✅      | `ExecuteStreamAsync()` → IAsyncEnumerable         |
 |                  | Show/print                                   | ✅      | `ShowAsync()`, `ToStringAsync()`                  |
@@ -71,7 +71,7 @@ using var df = await context.SqlAsync( "SELECT customer_id, sum(amount) AS total
 await df.ShowAsync();
 
 // Access schema
-var schema = await df.GetSchemaAsync();
+var schema = df.GetSchema();
 foreach (var field in schema.FieldsList)
     ... // Process schema field (name, type, etc.)
 

--- a/examples/QueryData/Program.cs
+++ b/examples/QueryData/Program.cs
@@ -44,7 +44,7 @@ Console.WriteLine($"Total rows: {await df.CountAsync()}");
 Console.WriteLine();
 
 Console.WriteLine("=== Schema ===");
-var schema = await df.GetSchemaAsync();
+var schema = df.GetSchema();
 foreach (var field in schema.FieldsList)
     Console.WriteLine($"  {field.Name}: {field.DataType}");
 Console.WriteLine();

--- a/src/DataFusionSharp/DataFrame.cs
+++ b/src/DataFusionSharp/DataFrame.cs
@@ -56,7 +56,7 @@ public sealed partial class DataFrame : IDisposable, ICloneable
             throw new DataFusionException(result, "Failed to parameterize DataFrame with SQL parameters");
         }
         
-        SyncOperations.Instance.PeekResult(id);
+        SyncOperations.Instance.TakeResult(id);
         
         return this;
     }
@@ -122,11 +122,11 @@ public sealed partial class DataFrame : IDisposable, ICloneable
     /// <summary>
     /// Returns the Arrow schema of this DataFrame.
     /// </summary>
-    /// <returns>A task containing the <see cref="Schema"/>.</returns>
+    /// <returns>A <see cref="Schema"/>.</returns>
     /// <exception cref="DataFusionException">Thrown when the operation fails.</exception>
-    public Task<Schema> GetSchemaAsync()
+    public Schema GetSchema()
     {
-        var (id, tcs) = AsyncOperations.Instance.Create<Schema>();
+        var id = SyncOperations.Instance.Create();
         var result = NativeMethods.DataFrameSchema(_handle, CallbackForGetSchemaHandle, id);
         if (result != DataFusionErrorCode.Ok)
         {
@@ -134,7 +134,7 @@ public sealed partial class DataFrame : IDisposable, ICloneable
             throw new DataFusionException(result, "Failed to start getting DataFrame schema");
         }
 
-        return tcs.Task;
+        return SyncOperations.Instance.TakeResult<Schema>(id);
     }
     
     /// <summary>
@@ -314,7 +314,7 @@ public sealed partial class DataFrame : IDisposable, ICloneable
         if (error != IntPtr.Zero)
         {
             var ex = ErrorInfoData.FromIntPtr(error).ToException();
-            AsyncOperations.Instance.CompleteWithError<Schema>(handle, ex);
+            SyncOperations.Instance.CompleteWithError<Schema>(handle, ex);
             return;
         }
 
@@ -325,11 +325,11 @@ public sealed partial class DataFrame : IDisposable, ICloneable
         }
         catch (Exception ex)
         {
-            AsyncOperations.Instance.CompleteWithError<Schema>(handle, ex);
+            SyncOperations.Instance.CompleteWithError<Schema>(handle, ex);
             return;
         }
         
-        AsyncOperations.Instance.CompleteWithResult(handle, schema);
+        SyncOperations.Instance.CompleteWithResult(handle, schema);
     }
     
     [DataFusionSharpNativeCallback]

--- a/src/DataFusionSharp/Interop/SyncOperations.cs
+++ b/src/DataFusionSharp/Interop/SyncOperations.cs
@@ -24,7 +24,17 @@ internal sealed class SyncOperations
         _operations.TryAdd(id, new SyncOperationResult { Exception = exception });
     }
     
-    public void PeekResult(ulong id)
+    public void CompleteWithResult<TResult>(ulong id, TResult? result = default)
+    {
+        _operations.TryAdd(id, new SyncOperationResult<TResult> { Result = result });
+    }
+    
+    public void CompleteWithError<TResult>(ulong id, Exception exception)
+    {
+        _operations.TryAdd(id, new SyncOperationResult<TResult> { Exception = exception });
+    }
+    
+    public void TakeResult(ulong id)
     {
         if (!_operations.TryRemove(id, out var result) || result is not { } r)
             throw new DataFusionException(DataFusionErrorCode.Panic, "No result available for the given operation");
@@ -32,9 +42,25 @@ internal sealed class SyncOperations
         if (r.Exception is not null)
             throw r.Exception;
     }
+    
+    public TResult TakeResult<TResult>(ulong id)
+    {
+        if (!_operations.TryRemove(id, out var result) || result is not SyncOperationResult<TResult> r)
+            throw new DataFusionException(DataFusionErrorCode.Panic, "No result available for the given operation");
+        
+        if (r.Exception is not null)
+            throw r.Exception;
+        
+        return r.Result!;
+    }
 
     private class SyncOperationResult
     {
         public Exception? Exception { get; set; }
+    }
+    
+    private sealed class SyncOperationResult<TResult> : SyncOperationResult
+    {
+        public TResult? Result { get; set; }
     }
 }

--- a/src/DataFusionSharp/README.md
+++ b/src/DataFusionSharp/README.md
@@ -33,7 +33,7 @@ using var df = await context.SqlAsync( "SELECT customer_id, sum(amount) AS total
 await df.ShowAsync();
 
 // Access schema
-var schema = await df.GetSchemaAsync();
+var schema = df.GetSchema();
 foreach (var field in schema.FieldsList)
     ... // Process schema field (name, type, etc.)
 

--- a/tests/DataFusionSharp.Benchmark/DataFrameBenchmarks.cs
+++ b/tests/DataFusionSharp.Benchmark/DataFrameBenchmarks.cs
@@ -35,7 +35,7 @@ public class DataFrameBenchmarks
     public Task<ulong> CountAsync() => _dataFrame.CountAsync();
 
     [Benchmark]
-    public Task<Schema> GetSchemaAsync() => _dataFrame.GetSchemaAsync();
+    public Schema GetSchema() => _dataFrame.GetSchema();
 
     [Benchmark]
     public Task<DataFrameCollectedResult> CollectAsync() => _dataFrame.CollectAsync();

--- a/tests/DataFusionSharp.Benchmark/README.md
+++ b/tests/DataFusionSharp.Benchmark/README.md
@@ -15,11 +15,11 @@ dotnet run -c Release
 
 Tests DataFrame operations with varying row counts (1, 100, 10,000, 1,000,000 rows).
 
-| Benchmark        | Description                       |
-|------------------|-----------------------------------|
-| `CountAsync`     | Count rows in DataFrame           |
-| `GetSchemaAsync` | Retrieve Arrow schema             |
-| `CollectAsync`   | Collect all data as RecordBatches |
+| Benchmark      | Description                       |
+|----------------|-----------------------------------|
+| `CountAsync`   | Count rows in DataFrame           |
+| `GetSchema`    | Retrieve Arrow schema             |
+| `CollectAsync` | Collect all data as RecordBatches |
 
 ## Results
 
@@ -31,20 +31,20 @@ Neoverse-N1, 2 physical cores
 DefaultJob : .NET 10.0.3 (10.0.3, 10.0.326.7603), Arm64 RyuJIT armv8.0-a
 ```
 
-| Method         | RowCount | Mean         | Error     | StdDev    | Gen0      | Gen1      | Gen2      | Allocated |
-|--------------- |--------- |-------------:|----------:|----------:|----------:|----------:|----------:|----------:|
-| CountAsync     | 1        |   617.201 us | 2.8458 us | 2.5227 us |         - |         - |         - |     240 B |
-| GetSchemaAsync | 1        |     1.809 us | 0.0029 us | 0.0027 us |    0.0687 |         - |         - |    1176 B |
-| CollectAsync   | 1        |   361.289 us | 3.7899 us | 3.5451 us |         - |         - |         - |    1824 B |
-| CountAsync     | 100      |   616.386 us | 3.4186 us | 3.1978 us |         - |         - |         - |     240 B |
-| GetSchemaAsync | 100      |     1.726 us | 0.0031 us | 0.0029 us |    0.0687 |         - |         - |    1176 B |
-| CollectAsync   | 100      |   361.824 us | 3.0167 us | 2.8218 us |         - |         - |         - |    1824 B |
-| CountAsync     | 10000    |   620.959 us | 1.8969 us | 1.7743 us |         - |         - |         - |     240 B |
-| GetSchemaAsync | 10000    |     1.828 us | 0.0023 us | 0.0022 us |    0.0687 |         - |         - |    1176 B |
-| CollectAsync   | 10000    |   385.928 us | 1.3691 us | 1.2137 us |   18.0664 |   18.0664 |   18.0664 |    2302 B |
-| CountAsync     | 1000000  | 3,415.513 us | 8.8833 us | 8.3094 us |         - |         - |         - |     240 B |
-| GetSchemaAsync | 1000000  |     1.685 us | 0.0020 us | 0.0019 us |    0.0687 |         - |         - |    1176 B |
-| CollectAsync   | 1000000  | 3,001.268 us | 5.0928 us | 4.2527 us | 1230.4688 | 1230.4688 | 1230.4688 |   59737 B |
+| Method       | RowCount | Mean         | Error     | StdDev    | Gen0      | Gen1      | Gen2      | Allocated |
+|--------------|--------- |-------------:|----------:|----------:|----------:|----------:|----------:|----------:|
+| CountAsync   | 1        |   617.201 us | 2.8458 us | 2.5227 us |         - |         - |         - |     240 B |
+| GetSchema    | 1        |     1.809 us | 0.0029 us | 0.0027 us |    0.0687 |         - |         - |    1176 B |
+| CollectAsync | 1        |   361.289 us | 3.7899 us | 3.5451 us |         - |         - |         - |    1824 B |
+| CountAsync   | 100      |   616.386 us | 3.4186 us | 3.1978 us |         - |         - |         - |     240 B |
+| GetSchema    | 100      |     1.726 us | 0.0031 us | 0.0029 us |    0.0687 |         - |         - |    1176 B |
+| CollectAsync | 100      |   361.824 us | 3.0167 us | 2.8218 us |         - |         - |         - |    1824 B |
+| CountAsync   | 10000    |   620.959 us | 1.8969 us | 1.7743 us |         - |         - |         - |     240 B |
+| GetSchema    | 10000    |     1.828 us | 0.0023 us | 0.0022 us |    0.0687 |         - |         - |    1176 B |
+| CollectAsync | 10000    |   385.928 us | 1.3691 us | 1.2137 us |   18.0664 |   18.0664 |   18.0664 |    2302 B |
+| CountAsync   | 1000000  | 3,415.513 us | 8.8833 us | 8.3094 us |         - |         - |         - |     240 B |
+| GetSchema    | 1000000  |     1.685 us | 0.0020 us | 0.0019 us |    0.0687 |         - |         - |    1176 B |
+| CollectAsync | 1000000  | 3,001.268 us | 5.0928 us | 4.2527 us | 1230.4688 | 1230.4688 | 1230.4688 |   59737 B |
 
 ## Reference Results From Native DataFusion
 

--- a/tests/DataFusionSharp.Tests/CsvTests.cs
+++ b/tests/DataFusionSharp.Tests/CsvTests.cs
@@ -110,7 +110,7 @@ public sealed class CsvTests : FileFormatTests
         await Context.RegisterCsvAsync("test", tempFile.Path, options);
         using var df = await Context.SqlAsync("SELECT * FROM test");
         var count = await df.CountAsync();
-        var schema = await df.GetSchemaAsync();
+        var schema = df.GetSchema();
 
         // Assert
         Assert.Equal(2UL, count);
@@ -139,7 +139,7 @@ public sealed class CsvTests : FileFormatTests
         await Context.RegisterCsvAsync("test", tempFile.Path, options);
         using var df = await Context.SqlAsync("SELECT * FROM test");
         var count = await df.CountAsync();
-        var schema = await df.GetSchemaAsync();
+        var schema = df.GetSchema();
 
         // Assert
         Assert.Equal(2UL, count);
@@ -218,7 +218,7 @@ public sealed class CsvTests : FileFormatTests
         await Context.RegisterCsvAsync("test", tempFile.Path, options);
         using var df = await Context.SqlAsync("SELECT * FROM test");
         var count = await df.CountAsync();
-        var schema = await df.GetSchemaAsync();
+        var schema = df.GetSchema();
 
         // Assert
         Assert.Equal(2UL, count);
@@ -307,7 +307,7 @@ public sealed class CsvTests : FileFormatTests
         // Act
         await Context.RegisterCsvAsync("test", tempFile.Path, options);
         using var df = await Context.SqlAsync("SELECT * FROM test");
-        var schema = await df.GetSchemaAsync();
+        var schema = df.GetSchema();
 
         // Assert
         Assert.Equal(2, schema.FieldsList.Count);

--- a/tests/DataFusionSharp.Tests/DataFrameTests.cs
+++ b/tests/DataFusionSharp.Tests/DataFrameTests.cs
@@ -68,13 +68,13 @@ public sealed class DataFrameTests : IDisposable
     }
 
     [Fact]
-    public async Task GetSchemaAsync_ReturnsSchema()
+    public async Task GetSchema_ReturnsSchema()
     {
         // Arrange
         using var df = await _context.SqlAsync(GetIdValueTableSelectSql(1));
 
         // Act
-        var schema = await df.GetSchemaAsync();
+        var schema = df.GetSchema();
 
         // Assert
         Assert.NotNull(schema);
@@ -195,7 +195,7 @@ public sealed class DataFrameTests : IDisposable
         using var df = await _context.SqlAsync(GetIdValueTableSelectSql(5));
 
         // Act
-        var dfSchema = await df.GetSchemaAsync();
+        var dfSchema = df.GetSchema();
         
         using var stream = await df.ExecuteStreamAsync();
         var streamSchema = stream.Schema;

--- a/tests/DataFusionSharp.Tests/ParquetTests.cs
+++ b/tests/DataFusionSharp.Tests/ParquetTests.cs
@@ -52,7 +52,7 @@ public sealed class ParquetTests : FileFormatTests
         // Act
         await Context.RegisterParquetAsync("customers", DataSet.CustomersParquetPath, options);
         using var df = await Context.SqlAsync("SELECT * FROM customers");
-        var schema = await df.GetSchemaAsync();
+        var schema = df.GetSchema();
         var count = await df.CountAsync();
 
         // Assert

--- a/tests/DataFusionSharp.Tests/ScalarValueTests.cs
+++ b/tests/DataFusionSharp.Tests/ScalarValueTests.cs
@@ -126,7 +126,7 @@ public sealed class ScalarValueTests : IDisposable
     {
         // Act
         using var df = await _context.SqlAsync("SELECT $p AS val", [("p", param)]);
-        var schema = await df.GetSchemaAsync();
+        var schema = df.GetSchema();
         var str = await df.ToStringAsync();
         
         // Assert


### PR DESCRIPTION
There is no need to keep GetSchema async since this is a sync operation at datafusion